### PR TITLE
Feat 025 (#63)

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -303,6 +303,18 @@ Feat 023 (#55)
 - Merge pull request #60 from jcook3701/develop
 
 Feat 024 (#57)
+- Update template
+- Merge branch 'cookiecutter-template' into feat-025
+- Feat 025 (#61)
+
+* fix(security): Fix for security.md file markdown format.
+
+* chore(upgrade): Update template from itself (cookiecutter-cookiecutter) using ```cookiecutter_project_upgrader```.
+- Merge branch 'develop' into feat-025
+- Merge pull request #62 from jcook3701/develop
+
+Feat 025 (#61)
+- Merge branch 'develop' into feat-025
 
 ### 🐛 Fixed
 
@@ -311,6 +323,7 @@ Feat 024 (#57)
 - *(changelogs)* Removed changelogs make command from running during post hook generation scripts.
 - *(issues)* Fixes and updates to issue templates.  Added developer only template to avoid having to fill out user forms for each project task.
 - *(security)* Fix for security.md file markdown format.
+- *(license)* License fixes for the .cookiecutter_includes directory.
 
 ### 🚀 Added
 

--- a/changelogs/releases/v0.1.0.md
+++ b/changelogs/releases/v0.1.0.md
@@ -2,7 +2,7 @@
 # Changelog:
 # --------------------------------------------------
 
-## [0.1.0] - 2026-01-29
+## [0.1.0] - 2026-01-30
 
 ### ⚙️  Miscellaneous
 
@@ -303,6 +303,18 @@ Feat 023 (#55)
 - Merge pull request #60 from jcook3701/develop
 
 Feat 024 (#57)
+- Update template
+- Merge branch 'cookiecutter-template' into feat-025
+- Feat 025 (#61)
+
+* fix(security): Fix for security.md file markdown format.
+
+* chore(upgrade): Update template from itself (cookiecutter-cookiecutter) using ```cookiecutter_project_upgrader```.
+- Merge branch 'develop' into feat-025
+- Merge pull request #62 from jcook3701/develop
+
+Feat 025 (#61)
+- Merge branch 'develop' into feat-025
 
 ### 🐛 Fixed
 
@@ -311,6 +323,7 @@ Feat 024 (#57)
 - *(changelogs)* Removed changelogs make command from running during post hook generation scripts.
 - *(issues)* Fixes and updates to issue templates.  Added developer only template to avoid having to fill out user forms for each project task.
 - *(security)* Fix for security.md file markdown format.
+- *(license)* License fixes for the .cookiecutter_includes directory.
 
 ### 🚀 Added
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -60,6 +60,7 @@
     "ansible",
     "c/c++",
     "cookiecutter",
+    "documentation",
     "python",
     "ros2",
     "typescript"

--- a/{{ cookiecutter.project_slug }}/.cookiecutter_includes/gitignore.j2
+++ b/{{ cookiecutter.project_slug }}/.cookiecutter_includes/gitignore.j2
@@ -58,7 +58,7 @@ dist/
 *.o
 *.a
 *.out
-{% elif template_type in ["cookiecutter", "python"] %}
+{% elif template_type in ["cookiecutter", "documentation" "python"] %}
 {{ python }}
 {% elif template_type == "ros2" %}
 # =========================================

--- a/{{ cookiecutter.project_slug }}/.cookiecutter_includes/license/0bsd.j2
+++ b/{{ cookiecutter.project_slug }}/.cookiecutter_includes/license/0bsd.j2
@@ -1,21 +1,21 @@
 {#
 # obsd.j2 for cookiecutter-cookiecutter
 #
-# Copyright (c) 2026, Jared Cook
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, Jared Cook
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <www.gnu.org>.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
 {% set spdx = ["0BSD"] %}

--- a/{{ cookiecutter.project_slug }}/.cookiecutter_includes/license/__init__.j2
+++ b/{{ cookiecutter.project_slug }}/.cookiecutter_includes/license/__init__.j2
@@ -1,21 +1,21 @@
 {#
 # license/__init__.j2 for cookiecutter-cookiecutter
 #
-# Copyright (c) 2026, Jared Cook
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, Jared Cook
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <www.gnu.org>.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
 {% import '.cookiecutter_includes/license/license.j2' as _license with context %}

--- a/{{ cookiecutter.project_slug }}/.cookiecutter_includes/license/agpl-3.0.j2
+++ b/{{ cookiecutter.project_slug }}/.cookiecutter_includes/license/agpl-3.0.j2
@@ -1,21 +1,21 @@
 {#
 # agpl-3.0.j2 for cookiecutter-cookiecutter
 #
-# Copyright (c) 2026, Jared Cook
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, Jared Cook
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <www.gnu.org>.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
 {% set spdx = ["AGPL-3.0-or-later", "AGPL-3.0-only"] %}

--- a/{{ cookiecutter.project_slug }}/.cookiecutter_includes/license/apache-2.0.j2
+++ b/{{ cookiecutter.project_slug }}/.cookiecutter_includes/license/apache-2.0.j2
@@ -1,21 +1,21 @@
 {#
 # apache-2.0.j2 for cookiecutter-cookiecutter
 #
-# Copyright (c) 2026, Jared Cook
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, Jared Cook
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <www.gnu.org>.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
 {% set spdx = ["Apache-2.0"] %}

--- a/{{ cookiecutter.project_slug }}/.cookiecutter_includes/license/bsd-2-clause.j2
+++ b/{{ cookiecutter.project_slug }}/.cookiecutter_includes/license/bsd-2-clause.j2
@@ -1,21 +1,21 @@
 {#
 # bsd-2-clause.j2 for cookiecutter-cookiecutter
 #
-# Copyright (c) 2026, Jared Cook
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, Jared Cook
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <www.gnu.org>.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
 {% set spdx = ["BSD-2-Clause"] %}

--- a/{{ cookiecutter.project_slug }}/.cookiecutter_includes/license/bsd-3-clause.j2
+++ b/{{ cookiecutter.project_slug }}/.cookiecutter_includes/license/bsd-3-clause.j2
@@ -1,21 +1,21 @@
 {#
 # bsd-3-clause.j2 for cookiecutter-cookiecutter
 #
-# Copyright (c) 2026, Jared Cook
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, Jared Cook
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <www.gnu.org>.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
 {% set spdx = ["BSD-3-Clause"] %}

--- a/{{ cookiecutter.project_slug }}/.cookiecutter_includes/license/gpl-3.0.j2
+++ b/{{ cookiecutter.project_slug }}/.cookiecutter_includes/license/gpl-3.0.j2
@@ -1,21 +1,21 @@
 {#
 # gpl-3.0.j2 for cookiecutter-cookiecutter
 #
-# Copyright (c) 2026, Jared Cook
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, Jared Cook
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <www.gnu.org>.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
 {% set spdx = ["GPL-3.0-or-later", "GPL-3.0-only"] %}

--- a/{{ cookiecutter.project_slug }}/.cookiecutter_includes/license/license-data.j2
+++ b/{{ cookiecutter.project_slug }}/.cookiecutter_includes/license/license-data.j2
@@ -1,21 +1,21 @@
 {#
 #  license-data.j2 for cookiecutter-cookiecutter
 #
-# Copyright (c) 2026, Jared Cook
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, Jared Cook
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <www.gnu.org>.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
 {% import '.cookiecutter_includes/license/0bsd.j2' as _0bsd with context %}

--- a/{{ cookiecutter.project_slug }}/.cookiecutter_includes/license/license-header.j2
+++ b/{{ cookiecutter.project_slug }}/.cookiecutter_includes/license/license-header.j2
@@ -1,21 +1,21 @@
 {#
 # license-header.j2 for cookiecutter-cookiecutter
 #
-# Copyright (c) 2025, Jared Cook
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, Jared Cook
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <www.gnu.org>.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
 {% import '.cookiecutter_includes/license/license-data.j2' as lics %}

--- a/{{ cookiecutter.project_slug }}/.cookiecutter_includes/license/license.j2
+++ b/{{ cookiecutter.project_slug }}/.cookiecutter_includes/license/license.j2
@@ -1,21 +1,21 @@
 {#
 #  license.j2 for cookiecutter-cookiecutter
 #
-# Copyright (c) 2026, Jared Cook
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, Jared Cook
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <www.gnu.org>.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
 {% import '.cookiecutter_includes/license/license-data.j2' as lics %}

--- a/{{ cookiecutter.project_slug }}/.cookiecutter_includes/license/mit.j2
+++ b/{{ cookiecutter.project_slug }}/.cookiecutter_includes/license/mit.j2
@@ -1,21 +1,21 @@
 {#
 # mit.j2 for cookiecutter-cookiecutter
 #
-# Copyright (c) 2026, Jared Cook
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, Jared Cook
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <www.gnu.org>.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
 {% set spdx = ["MIT"] %}

--- a/{{ cookiecutter.project_slug }}/.cookiecutter_includes/license/unlicense.j2
+++ b/{{ cookiecutter.project_slug }}/.cookiecutter_includes/license/unlicense.j2
@@ -1,21 +1,21 @@
 {#
 # unlicense.j2 for cookiecutter-cookiecutter
 #
-# Copyright (c) 2026, Jared Cook
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, Jared Cook
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <www.gnu.org>.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
 {% set spdx = ["Unlicense"] %}

--- a/{{ cookiecutter.project_slug }}/.cookiecutter_includes/make/__init__.j2
+++ b/{{ cookiecutter.project_slug }}/.cookiecutter_includes/make/__init__.j2
@@ -1,21 +1,21 @@
 {#
 # make/__init__.j2 for cookiecutter-cookiecutter
 #
-# Copyright (c) 2025, Jared Cook
-# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, Jared Cook
+# SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <www.gnu.org>.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
 {% import '.cookiecutter_includes/make/clean.j2' as _clean with context %}

--- a/{{ cookiecutter.project_slug }}/.cookiecutter_includes/make/clean.j2
+++ b/{{ cookiecutter.project_slug }}/.cookiecutter_includes/make/clean.j2
@@ -1,21 +1,21 @@
 {#
 # make/clean.j2 for cookiecutter-cookiecutter
 #
-# Copyright (c) 2025, Jared Cook
-# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, Jared Cook
+# SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <www.gnu.org>.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
 {% macro clean(

--- a/{{ cookiecutter.project_slug }}/.cookiecutter_includes/make/docs.j2
+++ b/{{ cookiecutter.project_slug }}/.cookiecutter_includes/make/docs.j2
@@ -1,21 +1,21 @@
 {#
 # make/docs.j2 for cookiecutter-cookiecutter
 #
-# Copyright (c) 2025, Jared Cook
-# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, Jared Cook
+# SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <www.gnu.org>.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
 {% macro sphinx_cmds() -%}

--- a/{{ cookiecutter.project_slug }}/.cookiecutter_includes/make/help.j2
+++ b/{{ cookiecutter.project_slug }}/.cookiecutter_includes/make/help.j2
@@ -1,21 +1,21 @@
 {#
 # make/help.j2 for cookiecutter-cookiecutter
 #
-# Copyright (c) 2025, Jared Cook
-# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, Jared Cook
+# SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <www.gnu.org>.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
 {# TODO: I should probably add pre-commit, pre-release, & release to the menu. #}

--- a/{{ cookiecutter.project_slug }}/.cookiecutter_includes/make/lint.j2
+++ b/{{ cookiecutter.project_slug }}/.cookiecutter_includes/make/lint.j2
@@ -1,21 +1,21 @@
 {#
 # make/lint.j2 for cookiecutter-cookiecutter
 #
-# Copyright (c) 2025, Jared Cook
-# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, Jared Cook
+# SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <www.gnu.org>.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
 {%- macro header(

--- a/{{ cookiecutter.project_slug }}/.cookiecutter_includes/make/phony.j2
+++ b/{{ cookiecutter.project_slug }}/.cookiecutter_includes/make/phony.j2
@@ -1,21 +1,21 @@
 {#
 # make/phony.j2 for cookiecutter-cookiecutter
 #
-# Copyright (c) 2025, Jared Cook
-# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, Jared Cook
+# SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <www.gnu.org>.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
 {% macro phony(

--- a/{{ cookiecutter.project_slug }}/.cookiecutter_includes/make/python.j2
+++ b/{{ cookiecutter.project_slug }}/.cookiecutter_includes/make/python.j2
@@ -1,19 +1,19 @@
 {#
 # make/python.j2 for cookiecutter-cookiecutter
 #
-# Copyright (c) 2025, Jared Cook
-# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, Jared Cook
+# SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <www.gnu.org>.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}

--- a/{{ cookiecutter.project_slug }}/.cookiecutter_includes/make/settings.j2
+++ b/{{ cookiecutter.project_slug }}/.cookiecutter_includes/make/settings.j2
@@ -1,21 +1,21 @@
 {#
 # make/settings.j2 for cookiecutter-cookiecutter
 #
-# Copyright (c) 2025, Jared Cook
-# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, Jared Cook
+# SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <www.gnu.org>.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
 {% macro settings(

--- a/{{ cookiecutter.project_slug }}/.cookiecutter_includes/make/version.j2
+++ b/{{ cookiecutter.project_slug }}/.cookiecutter_includes/make/version.j2
@@ -1,21 +1,21 @@
 {#
 # make/version.j2 for cookiecutter-cookiecutter
 #
-# Copyright (c) 2025, Jared Cook
-# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, Jared Cook
+# SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <www.gnu.org>.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
 {% macro version() -%}

--- a/{{ cookiecutter.project_slug }}/.cookiecutter_includes/pyproject/__init__.j2
+++ b/{{ cookiecutter.project_slug }}/.cookiecutter_includes/pyproject/__init__.j2
@@ -1,19 +1,19 @@
 {#
 # pyproject/__init__.j2 for cookiecutter-cookiecutter
 #
-# Copyright (c) 2025, Jared Cook
-# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, Jared Cook
+# SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <www.gnu.org>.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}

--- a/{{ cookiecutter.project_slug }}/.cookiecutter_includes/tests/__init__.j2
+++ b/{{ cookiecutter.project_slug }}/.cookiecutter_includes/tests/__init__.j2
@@ -1,21 +1,21 @@
 {#
 # tests/__init__.j2 for cookiecutter-cookiecutter
 #
-# Copyright (c) 2025, Jared Cook
-# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, Jared Cook
+# SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <www.gnu.org>.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
 {% import '.cookiecutter_includes/tests/bake.j2' as _bake with context %}

--- a/{{ cookiecutter.project_slug }}/.cookiecutter_includes/tests/bake.j2
+++ b/{{ cookiecutter.project_slug }}/.cookiecutter_includes/tests/bake.j2
@@ -1,21 +1,21 @@
 {#
 # tests/bake.j2 for cookiecutter-cookiecutter
 #
-# Copyright (c) 2025, Jared Cook
-# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, Jared Cook
+# SPDX-License-Identifier: AGPL-3.0-or-later
 #
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <www.gnu.org>.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
 
@@ -23,9 +23,9 @@
     template_type
 ) -%}
 {# returns the test_file name depending on the template type. #}
-    {% if template_type in ["ansible", "c", "c++", "c/cc", "c/c++", "ros2"] -%}
-        LICENSE
-    {%- elif template_type == "cookiecutter" -%}
+    {% if template_type in ["ansible", "c", "c++", "ros2"] -%}
+        LICENSE.md
+    {%- elif template_type in ["cookiecutter", "documentation"] -%}
         Makefile
     {%- elif template_type == "python" -%}
         pyproject.toml
@@ -67,7 +67,7 @@ def test_bake_with_defaults(cookies: Cookies) -> None:
 #}
     {%- set use_default_slug = [
         "c", "c++", "c/cc", "c/c++",
-        "cookiecutter", "python", "ros2",
+        "cookiecutter", "documentation" "python", "ros2",
         "typescript"] -%}
 
     {% if template_type == "ansible" -%}

--- a/{{ cookiecutter.project_slug }}/.jinja-runtime.json
+++ b/{{ cookiecutter.project_slug }}/.jinja-runtime.json
@@ -3,7 +3,7 @@
         "search_paths": [
             ".",
             "./.cookiecutter_includes",
-            "./{{cookiecutter.project_slug}}"
+            {% raw %}"./{{ cookiecutter.project_slug }}"{% endraw %}
         ],
         "base_dir": "."
     },

--- a/{{ cookiecutter.project_slug }}/hooks/post_gen_project.py
+++ b/{{ cookiecutter.project_slug }}/hooks/post_gen_project.py
@@ -6,7 +6,7 @@
 	file_name='post_gen_project.py',
 	comment_style='hash') }}
 {%- set template_type = cookiecutter.template_type %}
-{%- set sub_template = cookiecutter._is_sub_template %}
+{%- set doc_templates = ["sphinx-cookiecutter", "github-docs-cookiecutter"] %}
 
 import json
 import os
@@ -15,7 +15,7 @@ from nutrimatic.core import make
 from nutrimatic.hooks.post_gen_logic import (
     {% if template_type ==  "ansible" %}
     generate_ansible_dirs,
-    {% elif sub_template == False  %}
+    {% elif template_type != "documentation" %}
     generate_cliff_changelog_dirs,
     {% endif %}
     generate_docs_templates,


### PR DESCRIPTION
* fix(security): Fix for security.md file markdown format.

* fix(license): license fixes for the .cookiecutter_includes directory.

* feat(template): Added 'documentation' to the template_type options.  This should fix the hooks issue.

