### PR TITLE
Feat 028 (#69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 -->
 <h1 id="cookiecutter-cookiecutter">cookiecutter-cookiecutter</h1>
 
+<p><a href="LICENSE.md"><img src="https://img.shields.io/github/license/jcook3701/cookiecutter-cookiecutter" alt="License" /></a></p>
+
 <p><strong>Author:</strong> Jared Cook<br />
-<strong>Version:</strong> 0.1.0<br />
-<strong>License:</strong> <a href="LICENSE"><img src="https://img.shields.io/github/license/jcook3701/cookiecutter-cookiecutter" alt="License" /></a></p>
+<strong>Version:</strong> 0.1.0</p>
 
 <h2 id="overview">Overview</h2>
 
@@ -34,6 +35,7 @@ The <strong>cookiecutter-cookiecutter</strong> is used to maintain the build and
 <hr />
 
 <p><strong>CI/CD Check List:</strong></p>
+
 <ul>
   <li><img src="https://github.com/jcook3701/cookiecutter-cookiecutter/actions/workflows/dependency-check.yml/badge.svg" alt="dependency-check" /></li>
   <li><img src="https://github.com/jcook3701/cookiecutter-cookiecutter/actions/workflows/format-check.yml/badge.svg" alt="format-check" /></li>
@@ -70,60 +72,41 @@ The <strong>cookiecutter-cookiecutter</strong> is used to maintain the build and
 
 <hr />
 
-<h2 id="commit-help">Commit Help</h2>
-
-<p><strong>Note:</strong> Commits are required to be conventional git commit message.  This helps with the auto-generation of the changelog files and is enforced by pre-commit.<br />
-<strong>example:</strong></p>
-
-<div class="language-shell highlighter-rouge"><div class="highlight"><pre class="highlight"><code>&lt;<span class="nb">type</span><span class="o">&gt;[</span>optional scope]: &lt;description&gt;
-
-<span class="o">[</span>optional body]
-
-<span class="o">[</span>optional footer<span class="o">(</span>s<span class="o">)]</span>
-</code></pre></div></div>
+<h2 id="getting-started">Getting Started</h2>
 
 <ul>
-  <li><code class="language-plaintext highlighter-rouge">&lt;type&gt;</code>: A required noun that describes the nature of the change.</li>
-  <li><code class="language-plaintext highlighter-rouge">[optional scope]</code>: An optional phrase within parentheses that specifies the part of the codebase being affected (e.g., fix(parser):).</li>
-  <li><code class="language-plaintext highlighter-rouge">&lt;description&gt;</code>: A required short, imperative-mood summary of the changes.</li>
-  <li><code class="language-plaintext highlighter-rouge">[optional body]</code>: A longer description providing additional context and “what and why” details.</li>
-  <li><code class="language-plaintext highlighter-rouge">[optional footer(s)]</code>: Used for adding meta-information, such as issue references (Fixes #123) or indicating breaking changes.</li>
+  <li><a href="https://jcook3701.github.io/cookiecutter-cookiecutter/manual/setup-guide/requirements">Requirements</a></li>
+  <li><a href="https://jcook3701.github.io/cookiecutter-cookiecutter/manual/introduction/installation-guide">Installation guide</a></li>
+</ul>
+
+<h2 id="documentation">Documentation</h2>
+
+<p>The cookiecutter-cookiecutter documentation is available at <a href="https://jcook3701.github.io/cookiecutter-cookiecutter">docs</a>.</p>
+
+<h2 id="contributing">Contributing</h2>
+
+<p>If you’re interested in contributing to the cookiecutter-cookiecutter project:</p>
+<ul>
+  <li>Start by reading the <a href="https://jcook3701.github.io/cookiecutter-cookiecutter/manual/developer-resources/contribute">contributing guide</a>.</li>
+  <li>Learn how to setup your local environment, in our <a href="https://jcook3701.github.io/cookiecutter-cookiecutter/manual/contribute/developer-guide">developer guide</a>.</li>
+  <li>Look through our <a href="https://jcook3701.github.io/cookiecutter-cookiecutter/manual/contribute/style-guides/index">style guide</a>.</li>
 </ul>
 
 <hr />
 
-<h2 id="requirements">Requirements</h2>
-
-<p><strong>Python 3.11</strong></p>
-
-<div class="language-shell highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="nv">$ </span><span class="nb">sudo </span>apt <span class="nb">install </span>python3.11
-</code></pre></div></div>
-
-<p><strong><a href="https://github.com/jcook3701/nutri-matic">Nutri-Matic</a></strong><br />
-<strong>Note:</strong> This is needed for the cookiecutter hooks to run correctly.  Without this package installed in active python environment cookiecutter pull will fail.</p>
-
-<div class="language-shell highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="nv">$ </span>pip <span class="nb">install </span>nutri-matic
-</code></pre></div></div>
-
-<p><strong><a href="https://rust-lang.org/tools/install/">rustup</a></strong><br />
-<strong>Note:</strong> I found that it is easiest to use rustup to manage rustc and cargo but this is not required.<br />
-<strong>Example:</strong> Install rustup with the following:</p>
-
-<div class="language-shell highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="nv">$ </span>curl <span class="nt">--proto</span> <span class="s1">'=https'</span> <span class="nt">--tlsv1</span>.2 <span class="nt">-sSf</span> https://sh.rustup.rs | sh
-</code></pre></div></div>
-
-<p><strong><a href="https://git-cliff.org/">git-cliff</a></strong><br />
-<strong>Note:</strong> git-cliff can generate changelog files from the Git history by utilizing conventional commits as well as regex-powered custom parsers.</p>
-
-<div class="language-shell highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="nv">$ </span>cargo <span class="nb">install </span>git-cliff
-</code></pre></div></div>
-
-<hr />
-
-<h3 id="authors-notes">Authors Notes</h3>
+<h2 id="authors-notes">Authors Notes</h2>
 <ol>
-  <li>This code is currently intended to work with cookiecutter (v2.1+).</li>
+  <li>This code is currently intended to work with cookiecutter (v2.6+) from PyPi repositories.</li>
 </ol>
+
+<h2 id="license">License</h2>
+
+<p>Copyright (c) 2025-2026, Jared Cook</p>
+
+<p>This project is licensed under the <strong>AGPL-3.0-or-later License</strong>.<br />
+See the <a href="https://github.com/jcook3701/cookiecutter-cookiecutter/blob/master/LICENSE.md">LICENSE</a> file for the full license text.</p>
+
+<p>SPDX-License-Identifier: AGPL-3.0-or-later</p>
 
 <!--
 ### Helpful Emojis:

--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -334,6 +334,14 @@ Feat 025 (#63)
 - Merge pull request #66 from jcook3701/develop
 
 Feat 026 (#65)
+- Feat 027 (#67)
+
+* fix(template): Fixed missing commas that are causing gitignore error.
+
+* chore(update) Update template using ```cookiecutter_project_upgrader```.
+- Merge pull request #68 from jcook3701/develop
+
+Feat 027 (#67)
 
 ### 🐛 Fixed
 
@@ -341,7 +349,9 @@ Feat 026 (#65)
 - *(template)* Fixed git auto remove to ignore all readme files on merge.
 - *(changelogs)* Removed changelogs make command from running during post hook generation scripts.
 - *(issues)* Fixes and updates to issue templates.  Added developer only template to avoid having to fill out user forms for each project task.
-- *(template)* Fixed missing commas that are causing gitignore error.
+- *(python)* Fixed python configuration file license name.
+- *(docs)* Minor fix for license image shield.
+- *(docs)* Readme license fix.
 
 ### 🚀 Added
 
@@ -349,3 +359,4 @@ Feat 026 (#65)
 - *(git)* Added git attributes file to hopefully ignore updating specific files after they have been created. (#9)
 - *(fix)* General fixes for template to ensure proper upgrade functionality. (#13)
 - *(issues)* Setup issue templates. (#22)
+- *(docs)* Readme updates that link to github_io documentation.

--- a/changelogs/releases/v0.1.0.md
+++ b/changelogs/releases/v0.1.0.md
@@ -334,6 +334,14 @@ Feat 025 (#63)
 - Merge pull request #66 from jcook3701/develop
 
 Feat 026 (#65)
+- Feat 027 (#67)
+
+* fix(template): Fixed missing commas that are causing gitignore error.
+
+* chore(update) Update template using ```cookiecutter_project_upgrader```.
+- Merge pull request #68 from jcook3701/develop
+
+Feat 027 (#67)
 
 ### 🐛 Fixed
 
@@ -341,7 +349,9 @@ Feat 026 (#65)
 - *(template)* Fixed git auto remove to ignore all readme files on merge.
 - *(changelogs)* Removed changelogs make command from running during post hook generation scripts.
 - *(issues)* Fixes and updates to issue templates.  Added developer only template to avoid having to fill out user forms for each project task.
-- *(template)* Fixed missing commas that are causing gitignore error.
+- *(python)* Fixed python configuration file license name.
+- *(docs)* Minor fix for license image shield.
+- *(docs)* Readme license fix.
 
 ### 🚀 Added
 
@@ -349,3 +359,4 @@ Feat 026 (#65)
 - *(git)* Added git attributes file to hopefully ignore updating specific files after they have been created. (#9)
 - *(fix)* General fixes for template to ensure proper upgrade functionality. (#13)
 - *(issues)* Setup issue templates. (#22)
+- *(docs)* Readme updates that link to github_io documentation.

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -24,6 +24,10 @@
     "CLA",
     "DCO"
   ],
+  "changelog": [
+    "git-cliff",
+    "antsibull"
+  ],
   "publication_year": "2025",
   "current_year": "{% now 'local', '%Y' %}",
   "__year_range": "{% if cookiecutter.publication_year == cookiecutter.current_year %}{{ cookiecutter.current_year }}{% else %}{{ cookiecutter.publication_year }}-{{ cookiecutter.current_year }}{% endif %}",

--- a/cspell.json
+++ b/cspell.json
@@ -3,6 +3,8 @@
     "language": "en",
     "useGitignore": true,
     "words": [
+        "antsibull",
+        "antsichaut",
         "bumpversion",
         "cla",
         "ccla",
@@ -16,16 +18,21 @@
         "endmacro",
         "endraw",
         "endset",
+        "flatpak",
         "gitcliff",
         "githubusercontent",
         "icla",
         "mkdirp",
+        "nameisok",
         "nutrimatic",
         "nutri-matic",
+        "pkg",
+        "pkgs",
         "pipaudit",
         "pip-audit",
         "pyproject",
         "pytest",
+        "pyupgrade",
         "rpmnew",
         "rustc",
         "streetsidesoftware",
@@ -35,7 +42,8 @@
         "venv",
         "visualstudio",
         "vsmarketplacebadge",
-        "yaml"
+        "yaml",
+        "yamlfixer"
     ],
     "flagWords": [
         "hte"

--- a/docs/jekyll/README.md
+++ b/docs/jekyll/README.md
@@ -1,21 +1,22 @@
 # {{ site.title }}
 
-__Author:__ {{ site.author }}  
-__Version:__ {{ site.version }}  
-__License:__ [![License](https://img.shields.io/github/license/jcook3701/cookiecutter-cookiecutter)](LICENSE)
+[![License](https://img.shields.io/github/license/{{ site.github_username }}{{ site.baseurl }})](LICENSE.md)
+
+**Author:** {{ site.author }}  
+**Version:** {{ site.version }}  
 
 ## Overview
 
 {{ site.description }}  
 
-__Utilizes:__  
-The __{{ site.title }}__ depends on the following repositories for its documentation and sub-features.  
+**Utilizes:**  
+The **{{ site.title }}** depends on the following repositories for its documentation and sub-features.  
 * [Github docs](https://github.com/jcook3701/github-docs-cookiecutter) cookiecutter template generation.
 * [Nutri-Matic](https://github.com/jcook3701/nutri-matic) cookiecutter utilities for streamlining development and utilization of Cookiecutter templates.
 <!-- * [Sphinx docs](https://github.com/jcook3701/sphinx-cookiecutter) template generation. -->
 
-__Maintains:__  
-The __{{ site.title }}__ is used to maintain the build and ci/cd structure for the following projects.  
+**Maintains:**  
+The **{{ site.title }}** is used to maintain the build and ci/cd structure for the following projects.  
 * [github-docs-cookiecutter](https://github.com/jcook3701/github-docs-cookiecutter) Github docs cookiecutter template generation.  
 * [sphinx-cookiecutter](https://github.com/jcook3701/sphinx-cookiecutter) sphinx cookiecutter template generation.  
 * [ansible-galaxy-cookiecutter](https://github.com/jcook3701/ansible-galaxy-cookiecutter) Ansible Galaxy cookiecutter template + integration with Github docs cookiecutter template generation.  
@@ -24,7 +25,8 @@ The __{{ site.title }}__ is used to maintain the build and ci/cd structure for t
 
 ***
 
-__CI/CD Check List:__  
+**CI/CD Check List:**
+
 * ![dependency-check](https://github.com/jcook3701/cookiecutter-cookiecutter/actions/workflows/dependency-check.yml/badge.svg)
 * ![format-check](https://github.com/jcook3701/cookiecutter-cookiecutter/actions/workflows/format-check.yml/badge.svg)
 * ![lint-check](https://github.com/jcook3701/cookiecutter-cookiecutter/actions/workflows/lint-check.yml/badge.svg)
@@ -37,8 +39,8 @@ __CI/CD Check List:__
 
 ## Usage Examples
 
-__Example 1:__ Pull from main branch.  
-__Note:__ [Nutri-Matic](https://github.com/jcook3701/nutri-matic) is needed in active python environment.  
+**Example 1:** Pull from main branch.  
+**Note:** [Nutri-Matic](https://github.com/jcook3701/nutri-matic) is needed in active python environment.  
 
 ```shell
 $ cookiecutter git@github.com:jcook3701/cookiecutter-cookiecutter.git \
@@ -47,7 +49,7 @@ $ cookiecutter git@github.com:jcook3701/cookiecutter-cookiecutter.git \
     description="Cookiecutter test project."
 ```
 
-__Example 2:__ Pull from develop branch.  
+**Example 2:** Pull from develop branch.  
 
 ```shell
 $ cookiecutter git@github.com:jcook3701/cookiecutter-cookiecutter.git \
@@ -57,65 +59,39 @@ $ cookiecutter git@github.com:jcook3701/cookiecutter-cookiecutter.git \
     description="Cookiecutter test project."
 ```
 
-__Note:__ replace ```test-project``` or any of the other variables with real context configuration variables.  
+**Note:** replace ```test-project``` or any of the other variables with real context configuration variables.  
 
 ***
 
-## Commit Help
+## Getting Started
 
-__Note:__ Commits are required to be conventional git commit message.  This helps with the auto-generation of the changelog files and is enforced by pre-commit.  
-__example:__  
+* [Requirements]({{ site.github_io_url }}/manual/setup-guide/requirements)
+* [Installation guide]({{ site.github_io_url }}/manual/introduction/installation-guide)  
 
-```shell
-<type>[optional scope]: <description>
+## Documentation
 
-[optional body]
+The {{ site.title }} documentation is available at [docs]({{ site.github_io_url }}).  
 
-[optional footer(s)]
-```
+## Contributing
 
-* ```<type>```: A required noun that describes the nature of the change.  
-* ```[optional scope]```: An optional phrase within parentheses that specifies the part of the codebase being affected (e.g., fix(parser):).  
-* ```<description>```: A required short, imperative-mood summary of the changes.  
-* ```[optional body]```: A longer description providing additional context and "what and why" details.  
-* ```[optional footer(s)]```: Used for adding meta-information, such as issue references (Fixes #123) or indicating breaking changes.  
+If you're interested in contributing to the {{ site.title }} project:  
+* Start by reading the [contributing guide]({{ site.github_io_url }}/manual/developer-resources/contribute).  
+* Learn how to setup your local environment, in our [developer guide]({{ site.github_io_url }}/manual/contribute/developer-guide).  
+* Look through our [style guide]({{ site.github_io_url }}/manual/contribute/style-guides/index).  
 
 ***
 
-## Requirements
+## Authors Notes
+1. This code is currently intended to work with cookiecutter (v2.6+) from PyPi repositories.
 
-__Python 3.11__  
+## License
 
-```shell
-$ sudo apt install python3.11
-```
+{{ site.copyright }}  
 
-__[Nutri-Matic](https://github.com/jcook3701/nutri-matic)__  
-__Note:__ This is needed for the cookiecutter hooks to run correctly.  Without this package installed in active python environment cookiecutter pull will fail.  
+This project is licensed under the **{{ site.license }} License**.  
+See the [LICENSE]({{ site.repo_blob }}/LICENSE.md) file for the full license text.  
 
-```shell
-$ pip install nutri-matic
-```
-
-__[rustup](https://rust-lang.org/tools/install/)__  
-__Note:__ I found that it is easiest to use rustup to manage rustc and cargo but this is not required.  
-__Example:__ Install rustup with the following:  
-
-```shell
-$ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-```
-
-__[git-cliff](https://git-cliff.org/)__  
-__Note:__ git-cliff can generate changelog files from the Git history by utilizing conventional commits as well as regex-powered custom parsers.  
-
-```shell
-$ cargo install git-cliff
-```
-
-***
-
-### Authors Notes
-1. This code is currently intended to work with cookiecutter (v2.1+).
+SPDX-License-Identifier: {{ site.license }}
 
 <!--
 ### Helpful Emojis:

--- a/{{ cookiecutter.project_slug }}/hooks/post_gen_project.py
+++ b/{{ cookiecutter.project_slug }}/hooks/post_gen_project.py
@@ -5,16 +5,16 @@
 	cookiecutter.project_slug,
 	file_name='post_gen_project.py',
 	comment_style='hash') }}
-{%- set template_type = cookiecutter.template_type %}
+{%- set changelog = cookiecutter.changelog %}
 
 import json
 import os
 
 from nutrimatic.core import make
 from nutrimatic.hooks.post_gen_logic import (
-    {% if template_type ==  "ansible" %}
+    {% if changelog ==  "antsibull" %}
     generate_ansible_dirs,
-    {% elif template_type != "documentation" %}
+    {% elif changelog == "git-cliff" %}
     generate_cliff_changelog_dirs,
     {% endif %}
     generate_docs_templates,
@@ -35,9 +35,9 @@ def main() -> None:
     context = json.loads("""{{ cookiecutter | jsonify }}""")
     {% endraw %}
     generate_docs_templates(context)
-    {% if template_type ==  "ansible" %}
+    {% if changelog ==  "antsibull" %}
     generate_ansible_dirs()
-    {% elif template_type != "documentation" %}
+    {% elif changelog != "git-cliff" %}
     generate_cliff_changelog_dirs()
     {% endif %}
 

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -19,8 +19,8 @@ authors = [
 ]
 readme = "README.md"
 license = "{{ cookiecutter.license }}"
-license-files = ["LICENSE"]
-requires-python = ">=3.11"
+license-files = ["LICENSE.md"]
+requires-python = ">={{ cookiecutter.python_version }}"
 dependencies = [
   "nutri-matic>=0.1",
 ]


### PR DESCRIPTION
* fix(python): Fixed python configuration file license name.

* feat(docs): readme updates that link to github_io documentation.

* fix(docs): Minor fix for license image shield.

* fix(docs): readme license fix.

* fix(changelogs): Added configuration item for changelog tool selection.  Also updated hooks.  This should finally fixes #41.

