### PR TITLE
Feat 029 (#71)

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -342,6 +342,20 @@ Feat 026 (#65)
 - Merge pull request #68 from jcook3701/develop
 
 Feat 027 (#67)
+- Feat 028 (#69)
+
+* fix(python): Fixed python configuration file license name.
+
+* feat(docs): readme updates that link to github_io documentation.
+
+* fix(docs): Minor fix for license image shield.
+
+* fix(docs): readme license fix.
+
+* fix(changelogs): Added configuration item for changelog tool selection.  Also updated hooks.  This should finally fixes #41.
+- Merge pull request #70 from jcook3701/develop
+
+Feat 028 (#69)
 
 ### 🐛 Fixed
 
@@ -349,9 +363,9 @@ Feat 027 (#67)
 - *(template)* Fixed git auto remove to ignore all readme files on merge.
 - *(changelogs)* Removed changelogs make command from running during post hook generation scripts.
 - *(issues)* Fixes and updates to issue templates.  Added developer only template to avoid having to fill out user forms for each project task.
-- *(python)* Fixed python configuration file license name.
-- *(docs)* Minor fix for license image shield.
-- *(docs)* Readme license fix.
+- *(template)* Added none option to changelog selection to allow user to turn of this feature if needed.
+- *(upgrader)* Added changelog setting to upgrader configuration files.
+- *(hooks)* Fixed hook template for changelog configuration settings.
 
 ### 🚀 Added
 
@@ -359,4 +373,3 @@ Feat 027 (#67)
 - *(git)* Added git attributes file to hopefully ignore updating specific files after they have been created. (#9)
 - *(fix)* General fixes for template to ensure proper upgrade functionality. (#13)
 - *(issues)* Setup issue templates. (#22)
-- *(docs)* Readme updates that link to github_io documentation.

--- a/changelogs/releases/v0.1.0.md
+++ b/changelogs/releases/v0.1.0.md
@@ -342,6 +342,20 @@ Feat 026 (#65)
 - Merge pull request #68 from jcook3701/develop
 
 Feat 027 (#67)
+- Feat 028 (#69)
+
+* fix(python): Fixed python configuration file license name.
+
+* feat(docs): readme updates that link to github_io documentation.
+
+* fix(docs): Minor fix for license image shield.
+
+* fix(docs): readme license fix.
+
+* fix(changelogs): Added configuration item for changelog tool selection.  Also updated hooks.  This should finally fixes #41.
+- Merge pull request #70 from jcook3701/develop
+
+Feat 028 (#69)
 
 ### 🐛 Fixed
 
@@ -349,9 +363,9 @@ Feat 027 (#67)
 - *(template)* Fixed git auto remove to ignore all readme files on merge.
 - *(changelogs)* Removed changelogs make command from running during post hook generation scripts.
 - *(issues)* Fixes and updates to issue templates.  Added developer only template to avoid having to fill out user forms for each project task.
-- *(python)* Fixed python configuration file license name.
-- *(docs)* Minor fix for license image shield.
-- *(docs)* Readme license fix.
+- *(template)* Added none option to changelog selection to allow user to turn of this feature if needed.
+- *(upgrader)* Added changelog setting to upgrader configuration files.
+- *(hooks)* Fixed hook template for changelog configuration settings.
 
 ### 🚀 Added
 
@@ -359,4 +373,3 @@ Feat 027 (#67)
 - *(git)* Added git attributes file to hopefully ignore updating specific files after they have been created. (#9)
 - *(fix)* General fixes for template to ensure proper upgrade functionality. (#13)
 - *(issues)* Setup issue templates. (#22)
-- *(docs)* Readme updates that link to github_io documentation.

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -25,6 +25,7 @@
     "DCO"
   ],
   "changelog": [
+    "none",
     "git-cliff",
     "antsibull"
   ],

--- a/docs/cookiecutter_input.json
+++ b/docs/cookiecutter_input.json
@@ -43,6 +43,7 @@
     "add_sphinx_docs": false,
     "author": "Jared Cook",
     "buymeacoffee_username": "jcook3701",
+    "changelog": "git-cliff",
     "company": null,
     "contribution_model": "CLA",
     "copyright": "Copyright (c) 2025-2026, Jared Cook",

--- a/docs/jekyll/_manual/contribute/git-commit-message.md
+++ b/docs/jekyll/_manual/contribute/git-commit-message.md
@@ -8,7 +8,21 @@ parent: Contribute
 
 Commits are required to be conventional git commit messages.  This helps with the auto-generation of the changelog files and is enforced by [pre-commit](https://pre-commit.com/).  
 
-__example:__  
+**options (default):**
+
+* docs
+* chore
+* feat
+* fix
+* refactor
+* ci
+* test
+* perf
+* revert
+* build
+* style
+
+**example:**  
 
 ```shell
 <type>[optional scope]: <description>

--- a/docs/jekyll/_manual/troubleshooting/faq.md
+++ b/docs/jekyll/_manual/troubleshooting/faq.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Requirements
+title: FAQ
 nav_order: 1
 parent: Troubleshooting
 ---

--- a/docs/jekyll/_manual/troubleshooting/index.md
+++ b/docs/jekyll/_manual/troubleshooting/index.md
@@ -6,4 +6,4 @@ has_children: true
 ---
 ## Troubleshooting cookiecutter-cookiecutter
 
-* **[FAQ]({% link _manual/troubleshooting/faq.md %})** Common questions are answered in our [Frequently Asked Questions](https://jcook3701.github.io/cookiecutter-cookiecutter/manual/troubleshooting/faq.md).
+* **[FAQ]({% link _manual/troubleshooting/faq.md %})** Common questions are answered in our Frequently Asked Questions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ authors = [
 ]
 readme = "README.md"
 license = "AGPL-3.0-or-later"
-license-files = ["LICENSE"]
+license-files = ["LICENSE.md"]
 requires-python = ">=3.11"
 dependencies = [
   "nutri-matic>=0.1",

--- a/{{ cookiecutter.project_slug }}/hooks/post_gen_project.py
+++ b/{{ cookiecutter.project_slug }}/hooks/post_gen_project.py
@@ -37,7 +37,7 @@ def main() -> None:
     generate_docs_templates(context)
     {% if changelog ==  "antsibull" %}
     generate_ansible_dirs()
-    {% elif changelog != "git-cliff" %}
+    {% elif changelog == "git-cliff" %}
     generate_cliff_changelog_dirs()
     {% endif %}
 


### PR DESCRIPTION
* fix(template): Added none option to changelog selection to allow user to turn of this feature if needed.

* chore(update): Update template from ```cookiecutter-cookiecutter```.

* fix(upgrader): Added changelog setting to upgrader configuration files.

* fix(hooks): Fixed hook template for changelog configuration settings.

